### PR TITLE
Adjust renovate configuration for digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
   "commitMessagePrefix": "Update",
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
-  "commitMessageExtra": "from {{currentVersion}} to {{newVersion}}",
-  "commitBody": "Change-type: patch",
+  "commitBody": "Update {{depName}}\nChange-type: patch",
   "prHourlyLimit": 0,
   "labels": [
     "dependencies"
@@ -25,12 +24,6 @@
     },
     {
       "matchManagers": ["git-submodules"],
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    },
-    {
-      "matchManagers": ["git-submodules"],
-      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
The renovate git-submodule plugin does not support tag updates yet.

Remove the matchUpdateTypes that referred to tag versioning, and
add a `Update <dependency>` body for versionbot nested changelogs.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>