### PR TITLE
renovate: Replace Change-type with Changelog-entry

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "commitMessagePrefix": "Update",
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
-  "commitBody": "Update {{depName}}\nChange-type: patch",
+  "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}",
   "prHourlyLimit": 0,
   "labels": [
     "dependencies"


### PR DESCRIPTION
This configuration is to be used in device repositories, and their
versionist configuration requires a `Changelog-entry` to trigger instead
of a `Change-type`.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>