### PR TITLE
renovate: Disable pruning of stale branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "commitMessageTopic": "{{depName}}",
   "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}",
   "prHourlyLimit": 0,
+  "pruneStaleBranches": false,
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
This is needed so that renovate does not remove the versionbot build
branch whics is created on the `store-github` task and is required for
tagging on merge to master. The build branch is created in the
`renovate` namespace so the renovate bot considers it a stale branch.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>