### PR TITLE
Configure renovate to process forks

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,5 +35,6 @@
       "matchManagers": ["regex"],
       "automerge": true
     }
-  ]
+  ],
+  "includeForks": true
 }


### PR DESCRIPTION
When renovate is added for all repositories in an organization, this
setting defaults to false to forked repositories are not processed.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>