### PR TITLE
Revert "Configure renovate to process forks"

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,6 +35,5 @@
       "matchManagers": ["regex"],
       "automerge": true
     }
-  ],
-  "includeForks": true
+  ]
 }


### PR DESCRIPTION
Removate maintainers confirmed this setting does not work when in an
extends. It must also be contained in a `renovate.json` file in the
repository root, not for example in the `.github` folder.

This reverts commit d791161359a57893bdcfb4c7649356c6aebd0409.