### PR TITLE
Revert previous change that enabled all git-submodules

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,10 +47,6 @@
       "enabled": false
     },
     {
-      "matchManagers": ["git-submodules"],
-      "enabled": true
-    },
-    {
       "matchManagers": ["regex"],
       "enabled": true
     },


### PR DESCRIPTION
We only want submodules enabled for the packages in the patterns list.

Change-type: patch