### PR TITLE
Revert "Only apply digest commit body to digest update types"

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,6 +18,7 @@
   "commitMessagePrefix": "Update",
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
+  "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}",
   "prHourlyLimit": 0,
   "pruneStaleBranches": false,
   "git-submodules": {
@@ -27,9 +28,6 @@
   "allowPostUpgradeCommandTemplating": true,
   "allowedPostUpgradeCommands": ["^sed"],
   "automerge": false,
-  "digest": {
-    "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}"
-  },
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION

This reverts commit https://github.com/balena-os/renovate-config/commit/cd14afd39da1390f928f1ee063bc49f27685b741.

Change-type: patch