### PR TITLE
Use renovate automerge instead of custom labels

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,10 +24,10 @@
   "git-submodules": {
     "enabled": true
   },
-  "labels": ["renovate", "{{depType}}", "{{updateType}}", "no-review"],
+  "labels": ["renovate", "{{depType}}", "{{updateType}}"],
   "allowPostUpgradeCommandTemplating": true,
   "allowedPostUpgradeCommands": ["^sed"],
-  "automerge": false,
+  "automerge": true,
   "digest": {
     "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}"
   },


### PR DESCRIPTION
Renovate labels are not updated when PRs are rebased or change updateTypes, so they cannot be used
as a reliable source of truth.

Change-type: minor