### PR TITLE
Ignore all status checks when performing automerge

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,6 +28,7 @@
   "allowPostUpgradeCommandTemplating": true,
   "allowedPostUpgradeCommands": ["^sed"],
   "automerge": true,
+  "ignoreTests": true,
   "digest": {
     "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}"
   },


### PR DESCRIPTION
Because renovate does not consider branch protection rules and looks at all checks, automerge will fail if ANY test fails.

This is the only way to ignore checks that are failed but are not required by branch protection rules.

To prevent merging without required checks, we MUST ensure that balena-renovate[bot] does NOT have admin:write permissions or any other settings that would allow it to bypass protections.

Change-type: minor