### PR TITLE
Bump poky and meta-oe submodules if the branch is non-master

### DIFF
--- a/default.json
+++ b/default.json
@@ -50,6 +50,20 @@
     {
       "matchManagers": ["github-actions"],
       "enabled": true
+    },
+    {
+      "matchManagers": ["git-submodules"],
+      "matchPackagePatterns": ["/poky(.git)?$"],
+      "matchCurrentValue": "!/^master/",
+      "enabled": true,
+      "automerge": false
+    },
+    {
+      "matchManagers": ["git-submodules"],
+      "matchPackagePatterns": ["/meta-openembedded(.git)?$"],
+      "matchCurrentValue": "!/^master/",
+      "enabled": true,
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
This ensures that the branch property has been set in .gitmodules
in the repository before renovate will try to bump the commit.