### PR TITLE
renovate: Include helper to pin GHA digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:base",
     ":disableDependencyDashboard",
-    ":semanticCommitsDisabled"
+    ":semanticCommitsDisabled",
+    "helpers:pinGitHubActionDigests"
   ],
   "username": "balena-renovate[bot]",
   "gitAuthor": "Self-hosted Renovate Bot <133977723+balena-renovate[bot]@users.noreply.github.com>",


### PR DESCRIPTION
This is a secure step to ensure we are pinned to known versions of github actions.

Change-type: patch