### PR TITLE
correct allowedPostUpgradeCommands trust

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,7 +27,8 @@
   },
   "labels": ["renovate"],
   "allowPostUpgradeCommandTemplating": true,
-  "allowedPostUpgradeCommands": ["^sed"],
+  "allowedPostUpgradeCommands": ["^sed\\s+"],
+  "trustLevel": "high",
   "automerge": true,
   "automergeStrategy": "merge-commit",
   "digest": {


### PR DESCRIPTION
### [allowedPostUpgradeCommands](https://github.com/daekene/renovate/blob/master/docs/usage/self-hosted-configuration.md#allowedpostupgradecommands )

> A list of regular expressions that determine which commands in postUpgradeTasks are allowed to be executed. If this list is empty then no tasks will be executed. Also you need to have "trustLevel": "high", otherwise these tasks will be ignored.

.. according to the docs, these wouldn't have been working because `trustLevel": "high"` wasn't set.