### PR TITLE
Enable management all non-master branch meta-* submodules

### DIFF
--- a/default.json
+++ b/default.json
@@ -55,17 +55,11 @@
     },
     {
       "matchManagers": ["git-submodules"],
-      "matchPackagePatterns": ["/poky(.git)?$"],
+      "matchPackagePatterns": ["/(poky|meta-[a-z0-9]+)(.git)?$"],
       "matchCurrentValue": "!/^master/",
       "enabled": true,
-      "automerge": true
-    },
-    {
-      "matchManagers": ["git-submodules"],
-      "matchPackagePatterns": ["/meta-[a-z0-9]+(.git)?$"],
-      "matchCurrentValue": "!/^master/",
-      "enabled": true,
-      "automerge": true
+      "automerge": true,
+      "groupName": "meta-layers"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -62,7 +62,7 @@
     },
     {
       "matchManagers": ["git-submodules"],
-      "matchPackagePatterns": ["/meta-openembedded(.git)?$"],
+      "matchPackagePatterns": ["/meta-[a-z0-9]+(.git)?$"],
       "matchCurrentValue": "!/^master/",
       "enabled": true,
       "automerge": true


### PR DESCRIPTION
If we have a branch name set for an upstream submodule that is not master, we want Renovate to open PRs to bump to latest.

Change-type: patch