### PR TITLE
Temporarily disable management of meta-tci package

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,7 @@
   ],
   "onboarding": false,
   "autodiscover": true,
-  "autodiscoverFilter": ["balena-os/*"],
+  "autodiscoverFilter": ["balena-os/!(balena-tci)"],
   "requireConfig": "optional",
   "commitMessagePrefix": "Update",
   "commitMessageAction": "",
@@ -65,6 +65,10 @@
       "matchManagers": ["git-submodules","github-actions"],
       "matchPackagePatterns": ["{balena-os/,}balena-yocto-scripts"],
       "groupName": "balena-yocto-scripts"
+    },
+    {
+      "matchPackagePatterns": ["/meta-tci(.git)?$/"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
The repo `github.com/tci-development/meta-tci` has been moved
or deleted or made private and is causing Renovate to fail.

See: https://github.com/balena-os/balena-tci/issues/274
Change-type: patch