### PR TITLE
Remove the grouping of yocto-scripts

### DIFF
--- a/default.json
+++ b/default.json
@@ -62,11 +62,6 @@
       "groupName": "meta-layers"
     },
     {
-      "matchManagers": ["git-submodules","github-actions"],
-      "matchPackagePatterns": ["balena-yocto-scripts"],
-      "groupName": "balena-yocto-scripts"
-    },
-    {
       "matchPackagePatterns": ["meta-tci"],
       "enabled": false
     }


### PR DESCRIPTION
Grouping submodule digests and actions semver
doesn't work as expected and ends up force-pushing the changes again on every run.

Change-type: patch

See these alternating commits from the same PR
- https://github.com/balena-os/balena-raspberrypi/commit/8e5986d8fbde703d99b2de1bff37f2da0e213a5b
- https://github.com/balena-os/balena-raspberrypi/commit/570083acaccdf9f94a8671c005056ee458500a44