### PR TITLE
Disable the github-actions manager for balena-os/balena-yocto-scripts

### DIFF
--- a/default.json
+++ b/default.json
@@ -63,6 +63,11 @@
         "fileFilters": [".github/workflows/*.yml"],
         "executionMode": "update"
       }
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["balena-os/balena-yocto-scripts"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This dependency is managed via postUpgradeTasks along with the contracts submodule and we don't want multiple PRs to bump the same package.

See: https://balena.fibery.io/Inputs/Research/OS-testing-failures-and-issues-1147