### PR TITLE
Match and replace comments in yocto-scripts pinned commit

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,8 +1,0 @@
-# https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
-name: "Custom tests"
-description: "Run pre-commit hooks"
-runs:
-  using: "composite"
-  steps:
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+# Ignore auto-generated files
+exclude: ^(.versionbot/|CHANGELOG.md|VERSION)
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/default.json
+++ b/default.json
@@ -58,7 +58,7 @@
       "matchDepNames": ["balena-yocto-scripts"],
       "postUpgradeTasks": {
         "commands": [
-          "sed -E -i 's/(yocto-build-deploy\\.yml@)[^[:space:]]+$/\\1{{{newDigest}}}/' .github/workflows/*.yml"
+          "sed -E -i 's/(yocto-build-deploy\\.yml@).+$/\\1{{{newDigest}}}/' .github/workflows/*.yml"
         ],
         "fileFilters": [".github/workflows/*.yml"],
         "executionMode": "update"

--- a/repo.yml
+++ b/repo.yml
@@ -1,1 +1,1 @@
-type: 'node'
+type: generic


### PR DESCRIPTION
The existing sed expression was failing to match workflow commits that were previously pinned with a trailing semver comment.

Fixes matches like this
```yaml
uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@05b373abd099d1862fdff51e96b0122940505756 # v1.27.15
```
