### PR TITLE
Set weekend schedules for low-priority updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,9 +65,28 @@
       }
     },
     {
+      "description": "Disable GitHub Actions updates for balena-yocto-scripts as we use a post-upgrade task to update it to the latest commit",
       "matchManagers": ["github-actions"],
       "matchDepNames": ["balena-os/balena-yocto-scripts"],
       "enabled": false
+    },
+    {
+      "description": "Lower priority and weekend schedule github-actions updates",
+      "matchManagers": ["github-actions"],
+      "prPriority": -1,
+      "schedule": ["* * * * 0,6"]
+    },
+    {
+      "description": "Lower priority and weekend schedule devDependencies updates",
+      "matchDepTypes": ["devDependencies"],
+      "prPriority": -1,
+      "schedule": ["* * * * 0,6"]
+    },
+    {
+      "description": "Lower priority and weekend schedule pre-commit updates",
+      "matchManagers": ["pre-commit"],
+      "prPriority": -1,
+      "schedule": ["* * * * 0,6"]
     }
   ]
 }


### PR DESCRIPTION
This should improve renovate runtime, and reduce PR churn during business hours.

Change-type: minor
See: [#balena-io/os > Secure boot pentest @ 💬](https://balena.zulipchat.com/#narrow/channel/345889-balena-io.2Fos/topic/Secure.20boot.20pentest/near/543737105)
See: https://balena.fibery.io/Work/Improvement/Schedule-low-priority-dependencies-for-weekends-3331