### PR TITLE
Add best-practices config preset

### DIFF
--- a/.github/workflows/renovate-dry-run.yml
+++ b/.github/workflows/renovate-dry-run.yml
@@ -1,0 +1,32 @@
+name: Renovate Dry-Run
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+        description: "If true, the Renovate will not make any changes to the repository."
+        required: false
+
+permissions:
+  contents: read
+  id-token: write  # AWS GitHub OIDC required: write
+  packages: read   # Manage private ghcr.io dependencies
+
+jobs:
+  renovate:
+    strategy:
+      matrix:
+        include:
+          - config_file: default.json
+
+    uses: balena-io/renovate-config/.github/workflows/renovate.yml@master
+    secrets: inherit
+    with:
+      config_file: ${{ matrix.config_file }}
+      dry_run: ${{ inputs.dry_run || github.event_name == 'pull_request' }}
+      repositories: ${{ github.repository }}

--- a/default.json
+++ b/default.json
@@ -22,7 +22,21 @@
   },
   "packageRules": [
     {
+      "description": "Disable all managers by default for device-type repos",
       "matchPackagePatterns": ["*"],
+      "matchRepositories": [
+        "!balena-os/wifi-connect",
+        "!balena-os/leviathan",
+        "!balena-os/leviathan-worker",
+        "!balena-os/renovate-config",
+        "!balena-os/cloud-config",
+        "!balena-os/.github",
+        "!balena-os/balena-supervisor",
+        "!balena-os/yocto-dev",
+        "!balena-os/balena-sign",
+        "!balena-os/github-workflows",
+        "!balena-os/balena-yocto-scripts"
+      ],
       "excludePackagePatterns": [
         ".*meta-balena",
         ".*balena-yocto-scripts",

--- a/default.json
+++ b/default.json
@@ -14,6 +14,9 @@
   "git-submodules": {
     "enabled": true
   },
+  "pre-commit": {
+    "enabled": true
+  },
   "labels": ["renovate"],
   "automerge": true,
   "automergeStrategy": "merge-commit",

--- a/default.json
+++ b/default.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
+    "config:best-practices",
     ":semanticCommitsDisabled",
     "helpers:pinGitHubActionDigests"
   ],


### PR DESCRIPTION
This preset will help protect against supply-chain attacks.

Also, remove the disable-all managers defaults for repos that inherit configs from balena-io/renovate-config.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/OS-pipeline-blocked-by-crates.io-rate-limiting-205
See: https://balena.fibery.io/Work/Project/Renovate-Enable-best-practices-preset-2373

Unblocks https://github.com/balena-os/.github/pull/1582