### PR TITLE
Extend config from balena-io

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["github>balena-io/renovate-config"]
+  "extends": ["github>balena-io/renovate-config"],
+  "enabledManagers": [
+    "github-actions",
+    "custom.regex",
+    "pre-commit"
+  ]
 }

--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>balena-io/renovate-config",
     "config:recommended",
     "config:best-practices",
     ":semanticCommitsDisabled",
@@ -9,9 +10,13 @@
   "commitMessagePrefix": "Update",
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
-  "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newVersion}}",
   "prHourlyLimit": 0,
   "pruneStaleBranches": true,
+  "enabledManagers": [
+    "git-submodules",
+    "github-actions",
+    "custom.regex"
+  ],
   "git-submodules": {
     "enabled": true
   },
@@ -21,54 +26,46 @@
   "labels": ["renovate"],
   "automerge": true,
   "automergeStrategy": "merge-commit",
-  "digest": {
-    "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}"
-  },
   "packageRules": [
     {
-      "description": "Disable all managers by default for device-type repos",
-      "matchPackagePatterns": ["*"],
-      "matchRepositories": [
-        "!balena-os/wifi-connect",
-        "!balena-os/leviathan",
-        "!balena-os/leviathan-worker",
-        "!balena-os/renovate-config",
-        "!balena-os/cloud-config",
-        "!balena-os/.github",
-        "!balena-os/balena-supervisor",
-        "!balena-os/yocto-dev",
-        "!balena-os/balena-sign",
-        "!balena-os/github-workflows",
-        "!balena-os/balena-yocto-scripts"
+      "description": "Update dependencies with changelog entry",
+      "matchUpdateTypes": ["*"],
+      "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}}"
+    },
+    {
+      "description": "Update major/minor/patch dependencies with changelog entry",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newVersion}}"
+    },
+    {
+      "description": "Update digest dependencies with changelog entry",
+      "matchUpdateTypes": ["digest"],
+      "commitBody": "Update {{depName}}\nChangelog-entry: Update {{depName}} to {{newDigest}}"
+    },
+    {
+      "description": "Disable git-submodules for upstream layers using main/master branch refs",
+      "matchManagers": ["git-submodules"],
+      "matchPackageNames": [
+        "!layers/meta-balena",
+        "layers/poky",
+        "layers/meta-*"
       ],
-      "excludePackagePatterns": [
-        ".*meta-balena",
-        ".*balena-yocto-scripts",
-        ".*leviathan",
-        ".*contracts"
-      ],
+      "matchCurrentValue": "/(master|main)/",
       "enabled": false
     },
     {
-      "matchManagers": ["regex"],
-      "enabled": true,
-      "automerge": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "enabled": true,
-      "automerge": true
-    },
-    {
+      "description": "Group upstream meta-layer submodule updates (poky, meta-bsp, etc.)",
       "matchManagers": ["git-submodules"],
-      "matchPackagePatterns": ["poky", "meta-*"],
-      "matchCurrentValue": "!/(master|main)/",
-      "enabled": true,
-      "automerge": true,
+      "matchPackageNames": [
+        "!layers/meta-balena",
+        "layers/poky",
+        "layers/meta-*"
+      ],
       "groupName": "meta-layers"
     },
     {
-      "matchPackagePatterns": ["meta-tci"],
+      "matchPackageNames": ["meta-tci"],
+      "matchManagers": ["git-submodules"],
       "enabled": false
     },
     {
@@ -92,19 +89,19 @@
       "description": "Lower priority and weekend schedule github-actions updates",
       "matchManagers": ["github-actions"],
       "prPriority": -1,
-      "schedule": ["* * * * 0,6"]
+      "schedule": ["every weekend"]
     },
     {
       "description": "Lower priority and weekend schedule devDependencies updates",
       "matchDepTypes": ["devDependencies"],
       "prPriority": -1,
-      "schedule": ["* * * * 0,6"]
+      "schedule": ["every weekend"]
     },
     {
       "description": "Lower priority and weekend schedule pre-commit updates",
       "matchManagers": ["pre-commit"],
       "prPriority": -1,
-      "schedule": ["* * * * 0,6"]
+      "schedule": ["every weekend"]
     }
   ]
 }


### PR DESCRIPTION
Our primary config is balena-io and is always updated first
with the latest security and performance fixes.

List explicit enabledManagers to improve overall runtime
and disable features we don't use.

Move custom commitBody to packageRules so it overrides
the values set by balena-io/renovate-config.

See: https://balena.fibery.io/Work/Project/Renovate-Enable-best-practices-preset-2373

## Impact summary

Measured against a production dry-run after the upstream changes
([balena-io #1531](https://github.com/balena-io/renovate-config/pull/1531) + the no-group-all-digest follow-up) had landed.

Dry-run: https://github.com/balena-os/.github/actions/runs/25806607978?pr=1588

### New PRs: 6

All legitimate dependency updates that would have been scheduled regardless of
this change:

- `meta-balena` → balena-supervisor 17.7.x
- `balena-kontron-mx8mm` → layers/meta-balena digest
- `yocto-dev` → docker-buildx
- `linux-firmware` → balena-cli 23.2.x, 24.x, 25.x

### Autoclosed PRs: 76

| Count | Category |
|------:|----------|
|    19 | `balena-os/github-workflows` action PRs absorbed into group "Group GitHub Actions" |
|    14 | `product-os/flowzone` digest pins (no longer pinned per new packageRule) |
|    36 | residual per-dep digest PRs — stale-PR cleanup |
|     7 | `meta-layers` group refresh |

No net loss of update coverage — these are consolidations and cleanup, not lost updates.

### Manager coverage

- **Device-type repos** (extending `balena-os/renovate-config`): narrow allowlist
  - `git-submodules`
  - `github-actions`
  - `custom.regex`.
- **Polyglot / active-dev repos** (extending `balena-io/renovate-config` after
  balena-os in their `extends` chain): broader allowlist inherited from balena-io
  (npm, pip, cargo, dockerfile, docker-compose, helm, kubernetes, gomod, …).

No repo loses a manager it currently uses.