### PR TITLE
Disable prConcurrentLimit setting

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
   "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
   "pruneStaleBranches": true,
   "enabledManagers": [
     "git-submodules",


### PR DESCRIPTION
When we started inheriting config from balena-io/renovate-config it included a default prConcurrentLimit setting of 3, which limits each repo to a maximum of 3 PR branches at a time.

That is not a setting we have ever wanted to have enforced in balena-os so this change disables the inherited default.

Change-type: patch
See: https://balena.zulipchat.com/#narrow/channel/345889-balena-io.2Fos/topic/HUP.20size.20check/near/606116122